### PR TITLE
Fix #270: print a more descriptive error message when PQgetCopyData returns -1 (no error and no header/data)

### DIFF
--- a/src/include/postgres_binary_reader.hpp
+++ b/src/include/postgres_binary_reader.hpp
@@ -32,6 +32,10 @@ struct PostgresBinaryReader {
 
 		// len -1 signals end
 		if (len == -1) {
+			auto final_result = PQgetResult(con.GetConn());
+			if (!final_result || PQresultStatus(final_result) != PGRES_COMMAND_OK) {
+				throw IOException("Failed to fetch header for COPY: %s", string(PQresultErrorMessage(final_result)));
+			}
 			return false;
 		}
 

--- a/src/include/postgres_binary_reader.hpp
+++ b/src/include/postgres_binary_reader.hpp
@@ -20,6 +20,9 @@ struct PostgresBinaryReader {
 	~PostgresBinaryReader() {
 		Reset();
 	}
+	PostgresConnection &GetConn() {
+		return con;
+	}
 
 	bool Next() {
 		Reset();

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -8,7 +8,9 @@ void PostgresConnection::BeginCopyFrom(PostgresBinaryReader &reader, const strin
 	if (!result || PQresultStatus(result) != PGRES_COPY_OUT) {
 		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
 	}
-	reader.Next();
+	if (!reader.Next()) {
+		throw IOException("Failed to fetch header for COPY \"%s\"\n* This could signal e.g. a statement timeout or other connection failure", query);
+	}
 	reader.CheckHeader();
 }
 

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -9,7 +9,7 @@ void PostgresConnection::BeginCopyFrom(PostgresBinaryReader &reader, const strin
 		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
 	}
 	if (!reader.Next()) {
-		throw IOException("Failed to fetch header for COPY \"%s\"\n* This could signal e.g. a statement timeout or other connection failure", query);
+		throw IOException("Failed to fetch header for COPY \"%s\"", query);
 	}
 	reader.CheckHeader();
 }

--- a/test/sql/storage/attach_timeout_error.test
+++ b/test/sql/storage/attach_timeout_error.test
@@ -1,0 +1,15 @@
+# name: test/sql/storage/attach_timeout_error.test
+# description: Attach with timeout error
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner options=''-c statement_timeout=1000''' AS s (TYPE POSTGRES, READ_ONLY);
+
+statement error
+SELECT * FROM postgres_query(s, 'select count(*) from tpch.lineitem, tpch.lineitem t2, tpch.lineitem t3');
+----
+canceling statement due to statement timeout


### PR DESCRIPTION
Fixes #270

The issue is that Postgres can return `-1` from `PQgetCopyData` (indicating the COPY is finished). This is almost always due to an error. We would previously throw a non-descriptive error here - we now fetch the actual error using `PQgetResult`.

For example:

```sql
ATTACH 'dbname=postgresscanner options=''-c statement_timeout=10000''' AS s (TYPE POSTGRES, READ_ONLY);
SELECT * FROM postgres_query(s, 'select count(*) from tbl, tbl t2');
```

This now throws the following error:

```
IO Error: Failed to fetch header for COPY: ERROR:  canceling statement due to statement timeout
```