### PR TITLE
Add support some commonly used types for legacy text protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake-build-debug
 postgres/postgres
 .clang-format
 postgres
+.cache

--- a/create-postgres-tables.sh
+++ b/create-postgres-tables.sh
@@ -28,6 +28,7 @@ rm -rf /tmp/postgresscannertmp
 
 psql -d postgresscanner < test/all_pg_types.sql
 psql -d postgresscanner < test/decimals.sql
+psql -d postgresscanner < test/legacy_text_protocol.sql
 psql -d postgresscanner < test/other.sql
 
 

--- a/src/include/postgres_binary_reader.hpp
+++ b/src/include/postgres_binary_reader.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "postgres_conversion.hpp"
+#include "postgres_connection.hpp"
 
 namespace duckdb {
 

--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -16,6 +16,7 @@ namespace duckdb {
 class PostgresBinaryWriter;
 class PostgresTextWriter;
 struct PostgresBinaryReader;
+struct PostgresTextReader;
 class PostgresSchemaEntry;
 class PostgresTableEntry;
 class PostgresStatement;
@@ -62,6 +63,7 @@ public:
 	void FinishCopyTo(PostgresCopyState &state);
 
 	void BeginCopyFrom(PostgresBinaryReader &reader, const string &query);
+	void ReadTextFrom(PostgresTextReader &reader, const string &query);
 
 	bool IsOpen();
 	void Close();

--- a/src/include/postgres_result.hpp
+++ b/src/include/postgres_result.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "libpq-fe.h"
 #include "postgres_utils.hpp"
 
 namespace duckdb {

--- a/src/include/postgres_text_reader.hpp
+++ b/src/include/postgres_text_reader.hpp
@@ -1,0 +1,198 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// postgres_text_reader.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/common/types/interval.hpp"
+#include "libpq-fe.h"
+#include "postgres_conversion.hpp"
+#include "postgres_connection.hpp"
+#include <cstring>
+
+namespace duckdb {
+
+struct PostgresTextReader {
+	explicit PostgresTextReader(PostgresConnection &con_p) : con(con_p), current_result(nullptr), 
+                                                         current_row(0), current_field(0) {
+	}
+	
+	~PostgresTextReader() {
+		Reset();
+	}
+	
+	PostgresConnection &GetConn() {
+		return con;
+	}
+
+	bool ReadTextFrom(const string &query) {
+		Reset();
+		current_result = PQexec(con.GetConn(), query.c_str());
+		if (!current_result) {
+			throw IOException("Failed to execute query: %s", string(PQerrorMessage(con.GetConn())));
+		}
+		
+		auto status = PQresultStatus(current_result);
+		if (status != PGRES_TUPLES_OK && status != PGRES_SINGLE_TUPLE) {
+			string error_msg = string(PQresultErrorMessage(current_result));
+			Reset();
+			throw IOException("Query failed: %s", error_msg);
+		}
+		
+		rows = PQntuples(current_result);
+		fields = PQnfields(current_result);
+		current_row = 0;
+		current_field = 0;
+		
+		return rows > 0;
+	}
+
+	bool NextRow() {
+		if (!current_result || current_row >= rows) {
+			return false;
+		}
+		current_row++;
+		current_field = 0;
+		return current_row < rows;
+	}
+	
+	bool NextField() {
+		if (!current_result || current_field >= fields) {
+			return false;
+		}
+		current_field++;
+		return current_field < fields;
+	}
+	
+	void Reset() {
+		if (current_result) {
+			PQclear(current_result);
+			current_result = nullptr;
+		}
+		current_row = 0;
+		current_field = 0;
+		rows = 0;
+		fields = 0;
+	}
+	
+	bool Ready() {
+		return current_result != nullptr && current_row < rows && current_field < fields;
+	}
+
+	bool Done() {
+		return !Ready();
+	}
+	
+	// Check if the current field is NULL
+	bool IsNull() {
+		return PQgetisnull(current_result, current_row, current_field) != 0;
+	}
+	
+	// Basic type readers
+	template <class T>
+	T ReadInteger(const char* str, idx_t len) {
+		T result;
+		return (T)std::stoll(string(str, len));
+	}
+
+	template <class T>
+	T ReadUInteger(const char* str, idx_t len) {
+		T result;
+		return (T)std::stoull(string(str, len));
+	}
+
+	inline bool ReadBoolean(const char* str) {
+		if (strcmp(str, "t") == 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	inline float ReadFloat(const char* str) {
+		return std::stof(str);
+	}
+
+
+	inline double ReadDouble(const char* str) {
+		return std::stod(str);
+	}
+
+	// Read current field as value for the specified type
+	void ReadValue(const LogicalType &type, const PostgresType &postgres_type, Vector &out_vec, idx_t output_offset) {
+
+		if (IsNull()) {
+			FlatVector::SetNull(out_vec, output_offset, true);
+			return;
+		}
+		
+		char *value = PQgetvalue(current_result, current_row, current_field);
+		int len = PQgetlength(current_result, current_row, current_field);
+		
+		switch (type.id()) {
+		case LogicalTypeId::SMALLINT:
+			FlatVector::GetData<int16_t>(out_vec)[output_offset] = ReadInteger<int16_t>(value, len);
+			break;
+
+		case LogicalTypeId::INTEGER:
+			FlatVector::GetData<int32_t>(out_vec)[output_offset] = ReadInteger<int32_t>(value, len);
+			break;
+
+		case LogicalTypeId::BIGINT:
+			FlatVector::GetData<int64_t>(out_vec)[output_offset] = ReadInteger<int64_t>(value, len);
+			break;
+			
+		case LogicalTypeId::UINTEGER:
+			FlatVector::GetData<uint32_t>(out_vec)[output_offset] = ReadUInteger<uint32_t>(value, len);
+			break;
+
+
+
+		case LogicalTypeId::FLOAT:
+			FlatVector::GetData<bool>(out_vec)[output_offset] = ReadFloat(value);
+			break;
+
+		case LogicalTypeId::DOUBLE:
+			FlatVector::GetData<bool>(out_vec)[output_offset] = ReadDouble(value);
+			break;
+
+		
+		case LogicalTypeId::BLOB:
+		case LogicalTypeId::VARCHAR:
+			FlatVector::GetData<string_t>(out_vec)[output_offset] = StringVector::AddString(out_vec, value, len);
+			break;
+		
+		case LogicalTypeId::BOOLEAN:
+			FlatVector::GetData<bool>(out_vec)[output_offset] = ReadBoolean(value);
+			break;
+
+		case LogicalTypeId::DATE: {
+			FlatVector::GetData<date_t>(out_vec)[output_offset] = Date::FromString(value);
+			break;
+		}
+		case LogicalTypeId::TIMESTAMP: 
+			FlatVector::GetData<timestamp_t>(out_vec)[output_offset] = Timestamp::FromString(value);
+			break;
+	
+
+		default:
+			throw NotImplementedException("Type %s not implemented in text protocol reader", 
+										 LogicalTypeIdToString(type.id()));
+		}
+	}
+
+private:
+	PostgresConnection &con;
+	PGresult *current_result;
+	int current_row;
+	int current_field;
+	int rows;
+	int fields;
+};
+
+} // namespace duckdb

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -181,6 +181,8 @@ static void LoadInternal(DatabaseInstance &db) {
 	                          LogicalType::VARCHAR, Value(), SetPostgresNullByteReplacement);
 	config.AddExtensionOption("pg_debug_show_queries", "DEBUG SETTING: print all queries sent to Postgres to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetPostgresDebugQueryPrint);
+	config.AddExtensionOption("pg_use_legacy_text_protocol", "Whether or not to use legacy TEXT protocol to read data. Set this to yes will ignore pg_use_binary_copy",
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
 
 	OptimizerExtension postgres_optimizer;
 	postgres_optimizer.optimize_function = PostgresOptimizer::Optimize;

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -2,6 +2,7 @@
 
 #include <libpq-fe.h>
 
+#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/helper.hpp"
@@ -10,6 +11,7 @@
 #include "postgres_scanner.hpp"
 #include "postgres_result.hpp"
 #include "postgres_binary_reader.hpp"
+#include "postgres_text_reader.hpp"
 #include "storage/postgres_catalog.hpp"
 #include "storage/postgres_transaction.hpp"
 #include "storage/postgres_table_set.hpp"
@@ -33,6 +35,10 @@ struct PostgresLocalState : public LocalTableFunctionState {
 	PostgresPoolConnection pool_connection;
 
 	void ScanChunk(ClientContext &context, const PostgresBindData &bind_data, PostgresGlobalState &gstate,
+	               DataChunk &output);
+	void ScanChunkWithBinaryReader(ClientContext &context, const PostgresBindData &bind_data, PostgresGlobalState &gstate,
+	               DataChunk &output);
+	void ScanChunkWithTextReader(ClientContext &context, const PostgresBindData &bind_data, PostgresGlobalState &gstate,
 	               DataChunk &output);
 };
 
@@ -248,6 +254,18 @@ static void PostgresInitInternal(ClientContext &context, const PostgresBindData 
 			filter += " AND ";
 		}
 		filter += filter_string;
+	};
+	lstate.exec = false;
+	lstate.done = false;
+	Value use_legacy_text_protocol;
+	if (context.TryGetCurrentSetting("pg_use_legacy_text_protocol", use_legacy_text_protocol)) {
+		if (BooleanValue::Get(use_legacy_text_protocol)) {
+			lstate.sql = StringUtil::Format(
+				R"(SELECT %s FROM %s.%s %s%s;)",
+				col_names, KeywordHelper::WriteQuoted(bind_data->schema_name, '"'),
+				KeywordHelper::WriteQuoted(bind_data->table_name, '"'), filter, bind_data->limit);
+			return;
+		}
 	}
 	if (bind_data->table_name.empty()) {
 		D_ASSERT(!bind_data->sql.empty());
@@ -261,8 +279,7 @@ static void PostgresInitInternal(ClientContext &context, const PostgresBindData 
 		    col_names, KeywordHelper::WriteQuoted(bind_data->schema_name, '"'),
 		    KeywordHelper::WriteQuoted(bind_data->table_name, '"'), filter, bind_data->limit);
 	}
-	lstate.exec = false;
-	lstate.done = false;
+
 }
 
 static idx_t PostgresMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
@@ -417,7 +434,7 @@ static unique_ptr<LocalTableFunctionState> PostgresInitLocalState(ExecutionConte
 	return GetLocalState(context.client, input, gstate);
 }
 
-void PostgresLocalState::ScanChunk(ClientContext &context, const PostgresBindData &bind_data,
+void PostgresLocalState::ScanChunkWithBinaryReader(ClientContext &context, const PostgresBindData &bind_data,
                                    PostgresGlobalState &gstate, DataChunk &output) {
 	idx_t output_offset = 0;
 	PostgresBinaryReader reader(connection);
@@ -470,6 +487,50 @@ void PostgresLocalState::ScanChunk(ClientContext &context, const PostgresBindDat
 		reader.Reset();
 		output_offset++;
 	}
+}
+
+void PostgresLocalState::ScanChunkWithTextReader(ClientContext &context, const PostgresBindData &bind_data,
+                                   PostgresGlobalState &gstate, DataChunk &output) {
+	idx_t output_offset = 0;
+	PostgresTextReader reader(connection);
+	while (true) {
+		if (!exec) {
+			reader.ReadTextFrom(sql);
+			exec = true;
+		}
+	
+		output.SetCardinality(output_offset);
+		if (output_offset == STANDARD_VECTOR_SIZE) {
+			return;
+		}
+
+		if (reader.Done()) {
+			reader.Reset();
+			done = true;
+			return;
+		}
+
+		for (idx_t output_idx = 0; output_idx < output.ColumnCount(); output_idx++) {
+			auto col_idx = column_ids[output_idx];
+			auto &out_vec = output.data[output_idx];
+			reader.ReadValue(bind_data.types[col_idx], bind_data.postgres_types[col_idx], out_vec, output_offset);
+			reader.NextField();
+		}
+		reader.NextRow();
+		output_offset++;
+	}
+}
+
+void PostgresLocalState::ScanChunk(ClientContext &context, const PostgresBindData &bind_data,
+                                   PostgresGlobalState &gstate, DataChunk &output) {
+	Value use_legacy_text_protocol;
+	if (context.TryGetCurrentSetting("pg_use_legacy_text_protocol", use_legacy_text_protocol)) {
+		if (BooleanValue::Get(use_legacy_text_protocol)) {
+			ScanChunkWithTextReader(context, bind_data, gstate, output);
+			return;
+		}
+	}
+	ScanChunkWithBinaryReader(context, bind_data, gstate, output);
 }
 
 static void PostgresScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {

--- a/test/legacy_text_protocol.sql
+++ b/test/legacy_text_protocol.sql
@@ -1,0 +1,3 @@
+create table legacy_text_protocol (c1 integer, c2 text);
+insert into legacy_text_protocol values (1, 'a'), (2, 'b'), (3, 'foo');
+

--- a/test/sql/scanner/legacy_text_protocol.test
+++ b/test/sql/scanner/legacy_text_protocol.test
@@ -1,0 +1,25 @@
+# name: test/sql/scanner/legacy_text_protocol.test
+# description: Use legacy TEXT protocol to be compatible with Redshift database
+# group: [scanner]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+CALL postgres_attach('dbname=postgresscanner');
+
+statement ok
+SET pg_use_legacy_text_protocol=true;
+
+query I
+select c1 from legacy_text_protocol limit 1;
+----
+1
+
+query II
+select * from legacy_text_protocol;
+----
+1	a
+2	b
+3	foo


### PR DESCRIPTION
Add support for version 8 TEXT protocol without COPY, so the extension could also be used to query from Redshift.
The reason to mark this as `legacy` is because Postgres and Redshift TEXT protocol has started to diverge:
- Postgres 17 starts supporting getting result in chunk: https://www.postgresql.org/docs/17/libpq-single-row-mode.html
- Redshift supports `client_protocol_veresion=3` parameter, which will transfer some data types in more efficient binary format: https://www.amazonaws.cn/en/new/2022/amazon-redshift-open-source-odbc-driver-binary-protocol-support-performance/

I only use Duckdb as a light-weight, local Redshift for unit-testing and verification, so making this super fast and efficient is not that useful.