### PR TITLE
Fix #328 - Dont do limit pushdown during parallel execution

### DIFF
--- a/src/storage/postgres_optimizer.cpp
+++ b/src/storage/postgres_optimizer.cpp
@@ -54,6 +54,11 @@ static void OptimizePostgresScanLimitPushdown(unique_ptr<LogicalOperator> &op) {
 		}
 
 		auto &bind_data = get.bind_data->Cast<PostgresBindData>();
+		if (bind_data.max_threads != 1 || !bind_data.can_use_main_thread) {
+			// cannot push down limit/offset if we are not using the main thread
+			OptimizePostgresScanLimitPushdown(op->children[0]);
+			return;
+		}
 
 		string generated_limit_clause = "";
 		if (limit.limit_val.Type() != LimitNodeType::UNSET) {

--- a/test/sql/storage/limit.test
+++ b/test/sql/storage/limit.test
@@ -39,3 +39,35 @@ query II
 EXPLAIN FROM s.large_tbl LIMIT 5;
 ----
 logical_opt	<!REGEX>:.*LIMIT.*
+
+
+statement ok
+set pg_pages_per_task=1
+
+query I
+FROM s.large_tbl LIMIT 5
+----
+0
+1
+2
+3
+4
+
+query I
+FROM s.large_tbl LIMIT 5 OFFSET 5
+----
+5
+6
+7
+8
+9
+
+statement ok
+set explain_output='optimized_only'
+
+# limit is still in plan as we were not able to push down due to parallel execution
+
+query II
+EXPLAIN FROM s.large_tbl LIMIT 5;
+----
+logical_opt	<REGEX>:.*LIMIT.*


### PR DESCRIPTION
https://github.com/duckdb/duckdb-postgres/issues/328

LIMIT pushdown was added to this extension. https://github.com/duckdb/duckdb-postgres/pull/313  

It pushes LIMIT down to Postgres and removes it from the DuckDB query plan.
Problem is that parallelism can occur in the extension, and one Query gets turned into n postgres queries. Pushing LIMIT down then falsifies the result.

A test is added, using `set pg_pages_per_task=1`, that reproduces this by forcing parallelism.  

I added a check on `max_threads`, which makes it so that LIMIT is NOT pushed down, if it is anything other than `1`. 
This should prevent LIMIT from being pushed down in any case where we would have parallel queries from the best of my knowledge. **(There could be a better way to check for parallelism that I am not aware of)**

## Previously 

```sql
set pg_pages_per_task=1;
FROM s.large_tbl LIMIT 1;

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(0,0)'::tid AND '(1,0)'::tid LIMIT 1) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(1,0)'::tid AND '(2,0)'::tid LIMIT 1) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(2,0)'::tid AND '(3,0)'::tid LIMIT 1) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(3,0)'::tid AND '(4,0)'::tid LIMIT 1) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(4,0)'::tid AND '(5,0)'::tid LIMIT 1) TO STDOUT (FORMAT "binary");

┌────────────┐
│     i      │
│   int64    │
├────────────┤
│      70286 │
│      72772 │
│      74128 │
│      75032 │
│      76388 │
│      79100 │
```

### AFTER (NO LIMIT DURING PARALLEL)
```sql
set pg_pages_per_task=1;
FROM s.large_tbl LIMIT 1;

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(0,0)'::tid AND '(1,0)'::tid) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(1,0)'::tid AND '(2,0)'::tid) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(2,0)'::tid AND '(3,0)'::tid) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(3,0)'::tid AND '(4,0)'::tid) TO STDOUT (FORMAT "binary");

COPY (SELECT "i" FROM "public"."large_tbl" WHERE ctid BETWEEN '(4,0)'::tid AND '(5,0)'::tid) TO STDOUT (FORMAT "binary");

┌───────┐
│   i   │
│ int64 │
├───────┤
│   0   │
└───────┘
```