### PR TITLE
Fix various memory leaks

### DIFF
--- a/src/postgres_binary_reader.cpp
+++ b/src/postgres_binary_reader.cpp
@@ -71,8 +71,10 @@ bool PostgresBinaryReader::Next() {
 	if (len == -1) {
 		auto final_result = PQgetResult(con.GetConn());
 		if (!final_result || PQresultStatus(final_result) != PGRES_COMMAND_OK) {
+			PQclear(final_result);
 			throw IOException("Failed to fetch header for COPY: %s", string(PQresultErrorMessage(final_result)));
 		}
+		PQclear(final_result);
 		return false;
 	}
 
@@ -90,8 +92,10 @@ bool PostgresBinaryReader::Next() {
 void PostgresBinaryReader::CheckResult() {
 	auto result = PQgetResult(con.GetConn());
 	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
+		PQclear(result);
 		throw std::runtime_error("Failed to execute COPY: " + string(PQresultErrorMessage(result)));
 	}
+	PQclear(result);
 }
 
 void PostgresBinaryReader::Reset() {

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -74,6 +74,7 @@ unique_ptr<PostgresResult> PostgresConnection::TryQuery(const string &query, opt
 			*error_message = StringUtil::Format("Failed to execute query \"" + query +
 			                                    "\": " + string(PQresultErrorMessage(result)));
 		}
+		PQclear(result);
 		return nullptr;
 	}
 	return make_uniq<PostgresResult>(result);
@@ -107,10 +108,12 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(const stri
 			break;
 		}
 		if (ResultHasError(res)) {
+			PQclear(res);
 			throw std::runtime_error("Failed to execute query \"" + queries +
 			                         "\": " + string(PQresultErrorMessage(res)));
 		}
 		if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+			PQclear(res);
 			continue;
 		}
 		auto result = make_uniq<PostgresResult>(res);

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -6,8 +6,10 @@ namespace duckdb {
 void PostgresConnection::BeginCopyFrom(const string &query, ExecStatusType expected_result) {
 	auto result = PQExecute(query.c_str());
 	if (!result || PQresultStatus(result) != expected_result) {
+		PQclear(result);
 		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
 	}
+	PQclear(result);
 }
 
 } // namespace duckdb

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -58,8 +58,10 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 
 	auto result = PQExecute(query.c_str());
 	if (!result || PQresultStatus(result) != PGRES_COPY_IN) {
+		PQclear(result);
 		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
 	}
+	PQclear(result);
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a header
 		PostgresBinaryWriter writer(state);
@@ -106,8 +108,10 @@ void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
 	// fetch the query result to check for errors
 	auto result = PQgetResult(GetConn());
 	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
+		PQclear(result);
 		throw std::runtime_error("Failed to copy data: " + string(PQresultErrorMessage(result)));
 	}
+	PQclear(result);
 }
 
 bool NeedsQuotes(const string &to_quote, idx_t size) {


### PR DESCRIPTION
In a bunch of cases PQclear was not being called on a (possibly)
initialized `PGresult *`. This fixes those cases. These are all fairly
small memory leaks, but they could add up over time if multiple queries
to Postgres are being done.
