### PR TITLE
Fix #344: correctly finish binary copy in Postgres result reading to reset the connection back to idle

### DIFF
--- a/src/include/postgres_binary_reader.hpp
+++ b/src/include/postgres_binary_reader.hpp
@@ -24,7 +24,6 @@ public:
 
 protected:
 	bool Next();
-	void CheckResult();
 
 	void Reset();
 	bool Ready();

--- a/src/include/postgres_scanner.hpp
+++ b/src/include/postgres_scanner.hpp
@@ -22,6 +22,9 @@ class PostgresTransaction;
 struct PostgresBindData : public FunctionData {
 	static constexpr const idx_t DEFAULT_PAGES_PER_TASK = 1000;
 
+public:
+	PostgresBindData(ClientContext &context);
+
 	PostgresVersion version;
 	string schema_name;
 	string table_name;

--- a/src/postgres_binary_reader.cpp
+++ b/src/postgres_binary_reader.cpp
@@ -94,15 +94,6 @@ bool PostgresBinaryReader::Next() {
 	return true;
 }
 
-void PostgresBinaryReader::CheckResult() {
-	auto result = PQgetResult(con.GetConn());
-	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
-		PQclear(result);
-		throw std::runtime_error("Failed to execute COPY: " + string(PQresultErrorMessage(result)));
-	}
-	PQclear(result);
-}
-
 void PostgresBinaryReader::Reset() {
 	if (buffer) {
 		PQfreemem(buffer);

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -107,16 +107,14 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(const stri
 		if (!res) {
 			break;
 		}
+		auto result = make_uniq<PostgresResult>(res);
 		if (ResultHasError(res)) {
-			PQclear(res);
 			throw std::runtime_error("Failed to execute query \"" + queries +
 			                         "\": " + string(PQresultErrorMessage(res)));
 		}
 		if (PQresultStatus(res) != PGRES_TUPLES_OK) {
-			PQclear(res);
 			continue;
 		}
-		auto result = make_uniq<PostgresResult>(res);
 		results.push_back(std::move(result));
 	}
 	return results;

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -4,12 +4,11 @@
 namespace duckdb {
 
 void PostgresConnection::BeginCopyFrom(const string &query, ExecStatusType expected_result) {
-	auto result = PQExecute(query.c_str());
+	PostgresResult pg_res(PQExecute(query.c_str()));
+	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != expected_result) {
-		PQclear(result);
 		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
 	}
-	PQclear(result);
 }
 
 } // namespace duckdb

--- a/src/postgres_query.cpp
+++ b/src/postgres_query.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctionBindInput &input,
                                             vector<LogicalType> &return_types, vector<string> &names) {
-	auto result = make_uniq<PostgresBindData>();
+	auto result = make_uniq<PostgresBindData>(context);
 
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
 		throw BinderException("Parameters to postgres_query cannot be NULL");

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -39,7 +39,7 @@ TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique
 	auto &pg_catalog = catalog.Cast<PostgresCatalog>();
 	auto &transaction = Transaction::Get(context, catalog).Cast<PostgresTransaction>();
 
-	auto result = make_uniq<PostgresBindData>();
+	auto result = make_uniq<PostgresBindData>(context);
 
 	result->schema_name = schema.name;
 	result->table_name = name;

--- a/test/sql/scanner/postgres_query_error.test
+++ b/test/sql/scanner/postgres_query_error.test
@@ -1,0 +1,33 @@
+# name: test/sql/scanner/postgres_query_error.test
+# description: Test running postgres_query
+# group: [scanner]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+BEGIN
+
+statement ok
+CALL pg_clear_cache();
+
+query III
+select * from postgres_query('s1', 'SELECT * FROM cars');
+----
+ferari	testarosa	red
+aston martin	db2	blue
+bentley	mulsanne	gray
+ford	T	black
+
+query III
+SELECT * FROM s1.cars
+----
+ferari	testarosa	red
+aston martin	db2	blue
+bentley	mulsanne	gray
+ford	T	black
+


### PR DESCRIPTION
Fixes #344 

After running a binary copy we need to run `PQgetResult` until we no longer get back a result (not just once as is indicated in the docs). If we do not do this - the connection remains in a busy state and unable to process further queries. This does not matter in most cases because we open a new connection per transaction anyway - but when explicitly opening a transaction we re-use the same connection. 

In addition, this PR also fixes an issue where `pg_use_text_protocol` was not respected for `postgres_query` and `postgres_scan`. 