### PR TITLE
Fix #341: add mutex to querying using Postgres connection

### DIFF
--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -24,9 +24,12 @@ struct IndexInfo;
 
 struct OwnedPostgresConnection {
 	explicit OwnedPostgresConnection(PGconn *conn = nullptr);
+	OwnedPostgresConnection(const OwnedPostgresConnection &) = delete;
+	OwnedPostgresConnection &operator=(const OwnedPostgresConnection &) = delete;
 	~OwnedPostgresConnection();
 
 	PGconn *connection;
+	mutex connection_lock;
 };
 
 class PostgresConnection {

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -68,6 +68,7 @@ PGresult *PostgresConnection::PQExecute(const string &query) {
 }
 
 unique_ptr<PostgresResult> PostgresConnection::TryQuery(const string &query, optional_ptr<string> error_message) {
+	lock_guard<mutex> guard(connection->connection_lock);
 	auto result = PQExecute(query.c_str());
 	if (ResultHasError(result)) {
 		if (error_message) {

--- a/test/sql/storage/attach_show_all_tables.test
+++ b/test/sql/storage/attach_show_all_tables.test
@@ -1,4 +1,4 @@
-# name: test/sql/storage/attach_secret.test
+# name: test/sql/storage/attach_show_all_tables.test
 # description: Test attaching using a secret
 # group: [storage]
 

--- a/test/sql/storage/attach_show_all_tables.test
+++ b/test/sql/storage/attach_show_all_tables.test
@@ -1,0 +1,19 @@
+# name: test/sql/storage/attach_secret.test
+# description: Test attaching using a secret
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s
+
+statement ok
+SHOW ALL TABLES


### PR DESCRIPTION
Fixes #341 

The Postgres connection object is not thread-safe, we need to add an explicit mutex to the connection.