### PR TITLE
Fix idle transaction timeout error reporting

### DIFF
--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -101,8 +101,8 @@ unique_ptr<PostgresResult> PostgresConnection::TryQuery(optional_ptr<ClientConte
 
 	if (ResultHasError(result)) {
 		if (error_message) {
-			*error_message = StringUtil::Format("Failed to execute query \"" + query +
-			                                    "\": " + string(PQresultErrorMessage(result)));
+			*error_message =
+			    StringUtil::Format("Failed to execute query \"" + query + "\": " + string(PQerrorMessage(GetConn())));
 		}
 		PQclear(result);
 		return nullptr;

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -101,8 +101,8 @@ unique_ptr<PostgresResult> PostgresConnection::TryQuery(optional_ptr<ClientConte
 
 	if (ResultHasError(result)) {
 		if (error_message) {
-			*error_message =
-			    StringUtil::Format("Failed to execute query \"" + query + "\": " + string(PQerrorMessage(GetConn())));
+			auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+			*error_message = StringUtil::Format("Failed to execute query \"" + query + "\": " + string(error));
 		}
 		PQclear(result);
 		return nullptr;

--- a/test/sql/storage/attach_timeout_error.test
+++ b/test/sql/storage/attach_timeout_error.test
@@ -14,8 +14,8 @@ SELECT * FROM postgres_query(s, 'select count(*) from tpch.lineitem, tpch.lineit
 ----
 canceling statement due to statement timeout
 
-# A connection-level FATAL is delivered while the local transaction is doing
-# unrelated work, then surfaced by its rollback.
+# The server closes the connection while the local transaction is doing
+# unrelated work, then the failure is surfaced by its rollback.
 statement ok
 ATTACH 'dbname=postgresscanner port=5432 sslmode=allow options=''-c idle_in_transaction_session_timeout=100''' AS idle_timeout (TYPE POSTGRES, READ_ONLY);
 
@@ -33,4 +33,4 @@ SELECT sum(i) FROM range(1000000000) t(i);
 statement error
 ROLLBACK;
 ----
-terminating connection due to idle-in-transaction timeout
+server closed the connection unexpectedly

--- a/test/sql/storage/attach_timeout_error.test
+++ b/test/sql/storage/attach_timeout_error.test
@@ -13,3 +13,24 @@ statement error
 SELECT * FROM postgres_query(s, 'select count(*) from tpch.lineitem, tpch.lineitem t2, tpch.lineitem t3');
 ----
 canceling statement due to statement timeout
+
+# A connection-level FATAL is delivered while the local transaction is doing
+# unrelated work, then surfaced by its rollback.
+statement ok
+ATTACH 'dbname=postgresscanner port=5432 sslmode=allow options=''-c idle_in_transaction_session_timeout=100''' AS idle_timeout (TYPE POSTGRES, READ_ONLY);
+
+statement ok
+BEGIN;
+
+query I
+CALL postgres_query('idle_timeout', 'SELECT 1');
+----
+1
+
+statement ok
+SELECT sum(i) FROM range(1000000000) t(i);
+
+statement error
+ROLLBACK;
+----
+terminating connection due to idle-in-transaction timeout


### PR DESCRIPTION
Fixes #378. Preserve connection-level PostgreSQL FATAL errors when query cleanup rolls back a terminated connection. Adds an idle-in-transaction timeout regression test.