### PR TITLE
add connect_display option

### DIFF
--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -34,7 +34,7 @@ public:
 	explicit PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path, AccessMode access_mode,
 	                         vector<string> schemas_to_load, PostgresIsolationLevel isolation_level,
 	                         const string &secret_name, SecretStorageTable secret_storage_table_p,
-	                         PostgresTextProtocolMode text_protocol_mode);
+	                         PostgresTextProtocolMode text_protocol_mode, string connect_display = string());
 	~PostgresCatalog();
 
 	string attach_path;
@@ -149,6 +149,8 @@ private:
 	shared_ptr<PostgresConnectionPool> connection_pool;
 	string default_schema;
 	SecretStorageTable secret_storage_table;
+	//! Overrides what the shell prompt displays for this catalog - see GetConnectDisplay
+	string connect_display;
 
 	PostgresAwsRdsTokenConfig rds_token_config;
 	std::mutex rds_token_mutex;

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -87,6 +87,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	PostgresTextProtocolMode text_protocol_mode = PostgresTextProtocolMode::AUTO;
 	string secret_storage_table_name;
 	bool secret_storage_table_specified_explicitly = false;
+	string connect_display;
 	for (auto &entry : attach_options.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "secret") {
@@ -112,6 +113,11 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 		} else if (lower_name == "secret_storage_table") {
 			secret_storage_table_name = entry.second.ToString();
 			secret_storage_table_specified_explicitly = true;
+		} else if (lower_name == "connect_display") {
+			if (entry.second.IsNull()) {
+				throw BinderException("Value for \"CONNECT_DISPLAY\" option must not be null");
+			}
+			connect_display = entry.second.ToString();
 		} else {
 			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
 		}
@@ -120,7 +126,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	                                        secret_storage_table_specified_explicitly);
 	return make_uniq<PostgresCatalog>(context, db, std::move(attach_path), attach_options.access_mode,
 	                                  std::move(schemas_to_load), isolation_level, secret_name,
-	                                  std::move(secret_storage_table), text_protocol_mode);
+	                                  std::move(secret_storage_table), text_protocol_mode, std::move(connect_display));
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -9,6 +9,7 @@
 #include "storage/postgres_catalog.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "storage/postgres_transaction_manager.hpp"
+#include "utf8proc_wrapper.hpp"
 
 namespace duckdb {
 
@@ -49,6 +50,43 @@ static vector<string> ExtractSchemas(Value &value) {
 		throw BinderException("Value for `SCHEMA` option must be either \"VARCHAR\" or \"VARCHAR[]\", was: \"%s\"",
 		                      value.type().ToString());
 	}
+}
+
+//! The connect display is rendered verbatim into the shell prompt, so reject anything that could take over the
+//! terminal or trip up the code that renders it
+static string ExtractConnectDisplay(Value &value) {
+	if (value.IsNull()) {
+		throw BinderException("Value for \"CONNECT_DISPLAY\" option must not be null");
+	}
+	// generous upper bound - this is only here to keep pathological input from making the prompt unusable,
+	// every realistic endpoint is far below it
+	const idx_t max_width = 1024;
+	auto display = value.ToString();
+	// this has to happen before anything below inspects the string - RenderWidth walks UTF-8 sequences and
+	// relies on them being well formed
+	if (!Utf8Proc::IsValid(display.c_str(), display.size())) {
+		throw BinderException("Value for \"CONNECT_DISPLAY\" option must be valid UTF-8");
+	}
+	for (idx_t i = 0; i < display.size(); i++) {
+		auto c = static_cast<unsigned char>(display[i]);
+		// C0 control characters and DEL
+		bool is_control = c < 0x20 || c == 0x7f;
+		// C1 control characters - these are encoded as 0xC2 0x80 through 0xC2 0x9F in UTF-8
+		if (c == 0xc2 && i + 1 < display.size()) {
+			auto next = static_cast<unsigned char>(display[i + 1]);
+			is_control = is_control || (next >= 0x80 && next <= 0x9f);
+		}
+		if (is_control) {
+			throw BinderException("Value for \"CONNECT_DISPLAY\" option must not contain control characters - the "
+			                      "value is rendered directly into the shell prompt");
+		}
+	}
+	auto width = Utf8Proc::RenderWidth(display);
+	if (width > max_width) {
+		throw BinderException("Value for \"CONNECT_DISPLAY\" option must be at most %d columns wide, was %d", max_width,
+		                      idx_t(width));
+	}
+	return display;
 }
 
 static PostgresTextProtocolMode ExtractTextProtocolMode(Value &value) {
@@ -114,10 +152,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 			secret_storage_table_name = entry.second.ToString();
 			secret_storage_table_specified_explicitly = true;
 		} else if (lower_name == "connect_display") {
-			if (entry.second.IsNull()) {
-				throw BinderException("Value for \"CONNECT_DISPLAY\" option must not be null");
-			}
-			connect_display = entry.second.ToString();
+			connect_display = ExtractConnectDisplay(entry.second);
 		} else {
 			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
 		}

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -30,6 +30,12 @@ unique_ptr<TableRef> PostgresCatalog::RemoteExecute(ClientContext &context, cons
 }
 
 string PostgresCatalog::GetConnectDisplay() {
+	if (!connect_display.empty()) {
+		// an explicit display string was provided in the ATTACH - this is used by extensions that attach
+		// Postgres compatible databases (such as AWS RDS or Redshift) through this extension, so that the
+		// prompt can show how the database was attached instead of the Postgres connection we ended up with
+		return connect_display;
+	}
 	// `postgres://<host>[:<port>]` — standard postgres URI shorthand. dbname is already shown
 	// via current_database in the prompt, so it's omitted here.
 	string host, port;
@@ -73,12 +79,13 @@ unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_n
 PostgresCatalog::PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path_p,
                                  AccessMode access_mode, vector<string> schemas_to_load,
                                  PostgresIsolationLevel isolation_level, const string &secret_name,
-                                 SecretStorageTable secret_storage_table_p, PostgresTextProtocolMode text_protocol_mode)
+                                 SecretStorageTable secret_storage_table_p, PostgresTextProtocolMode text_protocol_mode,
+                                 string connect_display_p)
     : Catalog(db_p), attach_path(std::move(attach_path_p)), access_mode(access_mode), isolation_level(isolation_level),
       text_protocol_mode(text_protocol_mode), schemas(*this, schemas_to_load),
       connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)),
       default_schema(schemas_to_load.size() > 0 ? schemas_to_load[0] : std::string()),
-      secret_storage_table(std::move(secret_storage_table_p)) {
+      secret_storage_table(std::move(secret_storage_table_p)), connect_display(std::move(connect_display_p)) {
 	auto secret_entry = GetSecretEntry(ctx, secret_name);
 	this->rds_token_config = PostgresAws::ExtractTokenConfigFromSecret(secret_entry);
 	if (!rds_token_config.Enabled()) {

--- a/test/sql/storage/attach_connect_display.test
+++ b/test/sql/storage/attach_connect_display.test
@@ -1,0 +1,162 @@
+# name: test/sql/storage/attach_connect_display.test
+# description: Test validation of the CONNECT_DISPLAY attach option
+# group: [storage]
+
+require postgres_scanner
+
+# CONNECT_DISPLAY is validated while binding the ATTACH, before any connection is made, so none of this
+# needs a Postgres to connect to. Values that pass validation get as far as the connection attempt, which
+# is why the accepted cases below expect "Unable to connect to Postgres at".
+
+# NULL is rejected by DuckDB itself, before the option reaches the Postgres extension
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY NULL)
+----
+NULL is not supported as a valid option for ATTACH option "connect_display"
+
+# the value ends up in the shell prompt verbatim, so escape sequences must not survive
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'rds://x' || chr(27) || '[31m')
+----
+must not contain control characters
+
+# newline, carriage return and tab would all break up the prompt
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'line1' || chr(10) || 'line2')
+----
+must not contain control characters
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'a' || chr(13))
+----
+must not contain control characters
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'a' || chr(9) || 'b')
+----
+must not contain control characters
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'a' || chr(127))
+----
+must not contain control characters
+
+# C1 control characters - 0xC2 0x9B is CSI, which some terminals honour. These are multi-byte in UTF-8,
+# so a check that only looks at bytes below 0x20 would let them through.
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY chr(194) || chr(155))
+----
+must not contain control characters
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY chr(194) || chr(128))
+----
+must not contain control characters
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY repeat('x', 1025))
+----
+must be at most 1024 columns wide, was 1025
+
+# the limit is on rendered width, so wide characters count double
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY repeat('日', 513))
+----
+must be at most 1024 columns wide, was 1026
+
+# unrecognized options are still rejected
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY_NAME 'rds://my-instance')
+----
+Unrecognized option for Postgres attach: connect_display_name
+
+# --- values that pass validation ---
+
+# a realistic endpoint is nowhere near the width limit
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'redshift://my-cluster.abc123xyz789.eu-west-1.redshift.amazonaws.com:5439/analytics')
+----
+Unable to connect to Postgres at
+
+# exactly at the width limit, in both narrow and wide characters
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY repeat('x', 1024))
+----
+Unable to connect to Postgres at
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY repeat('日', 512))
+----
+Unable to connect to Postgres at
+
+# printable non-ASCII is fine - only control characters are rejected
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'rds://café-日本-🚀')
+----
+Unable to connect to Postgres at
+
+# an empty display string is accepted and falls back to the derived postgres://host:port
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY '')
+----
+Unable to connect to Postgres at
+
+# the option name is matched case insensitively
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, connect_display 'rds://x')
+----
+Unable to connect to Postgres at
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CoNnEcT_DiSpLaY 'rds://x')
+----
+Unable to connect to Postgres at
+
+# whitespace and zero width characters are not control characters, so they are accepted
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY '   ')
+----
+Unable to connect to Postgres at
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'a' || chr(8203) || 'b')
+----
+Unable to connect to Postgres at
+
+# there is no test for invalid UTF-8 because it cannot be reached from SQL - DuckDB VARCHAR is always
+# valid UTF-8, and casting a BLOB to VARCHAR yields the escaped text form rather than the raw bytes.
+# The UTF-8 check in ExtractConnectDisplay guards the C++ path, where a Value is built directly.
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY CAST('\xC3\x28'::BLOB AS VARCHAR))
+----
+Unable to connect to Postgres at
+
+# non-VARCHAR values are accepted and converted with ToString(), matching how SECRET is handled
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 42)
+----
+Unable to connect to Postgres at
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY ['a','b'])
+----
+Unable to connect to Postgres at
+
+# --- the option must not disturb the rest of the attach ---
+
+# omitting it entirely still binds - it is an optional constructor argument
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES)
+----
+Unable to connect to Postgres at
+
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'rds://x', SCHEMA 'public', READ_ONLY)
+----
+Unable to connect to Postgres at
+
+# repeating the option is resolved by DuckDB before the extension sees it
+statement error
+ATTACH 'dbname=nope' AS d (TYPE POSTGRES, CONNECT_DISPLAY 'a', CONNECT_DISPLAY 'b')
+----
+Unable to connect to Postgres at


### PR DESCRIPTION
DuckDB-aws has been adding extra functionality to connect to RDS/Redshift in an easier way. The only bit that is missing is overriding the connect_display when connecting to these services without using an `ATTACH`. The connect display name defaults to the uri, which can be ugly for sometimes

This PR will allow extensions that call postgres-attach to also override the display name if postgres instances are immediately `connect`ed to instead of `attached` first.

This option gives extensions the ability to override the display name for CONNECT statements (and `attach` statements if they want) with something a bit more readable.

Before in duckdb-aws
```
memory D connect 'redshift-attach-connect-test' (type redshift);
postgres://'redshift-attach-connect-test.ccg... D ... D 
```

After
```
memory D connect 'redshift-attach-connect-test' (type redshift);
redshift: redshift-attach-connect-test D  
```