### PR TITLE
Fix connection pool slot leak on COMMIT failure

### DIFF
--- a/src/include/storage/postgres_transaction_manager.hpp
+++ b/src/include/storage/postgres_transaction_manager.hpp
@@ -28,6 +28,8 @@ public:
 	void Checkpoint(ClientContext &context, bool force = false) override;
 
 private:
+	void DestroyTransaction(Transaction &transaction);
+
 	PostgresCatalog &postgres_catalog;
 	mutex transaction_lock;
 	reference_map_t<Transaction, unique_ptr<PostgresTransaction>> transactions;

--- a/src/storage/postgres_transaction_manager.cpp
+++ b/src/storage/postgres_transaction_manager.cpp
@@ -17,19 +17,34 @@ Transaction &PostgresTransactionManager::StartTransaction(ClientContext &context
 	return result;
 }
 
-ErrorData PostgresTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction) {
-	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
-	postgres_transaction.Commit();
+void PostgresTransactionManager::DestroyTransaction(Transaction &transaction) {
 	lock_guard<mutex> l(transaction_lock);
 	transactions.erase(transaction);
-	return ErrorData();
+}
+
+ErrorData PostgresTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction) {
+	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
+	ErrorData error;
+	try {
+		postgres_transaction.Commit();
+	} catch (const std::exception &ex) {
+		error = ErrorData(ex);
+	} catch (...) {
+		error = ErrorData("Server COMMIT failed");
+	}
+	DestroyTransaction(transaction);
+	return error;
 }
 
 void PostgresTransactionManager::RollbackTransaction(Transaction &transaction) {
 	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
-	postgres_transaction.Rollback();
-	lock_guard<mutex> l(transaction_lock);
-	transactions.erase(transaction);
+	try {
+		postgres_transaction.Rollback();
+	} catch (...) {
+		DestroyTransaction(transaction);
+		throw;
+	}
+	DestroyTransaction(transaction);
 }
 
 void PostgresTransactionManager::Checkpoint(ClientContext &context, bool force) {

--- a/test/sql/connection_pool/connection_pool_configure.test
+++ b/test/sql/connection_pool/connection_pool_configure.test
@@ -18,13 +18,13 @@ ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES);
 statement ok
 RESET GLOBAL pg_pool_max_connections
 
-query IIIIIIIIII
-SELECT catalog_name, max_connections, /*cache_hits,*/ cache_misses, try_failures, thread_local_cache_enabled, max_lifetime_millis, idle_timeout_millis, reaper_thread_running, reaper_thread_period_millis, health_check_query
+query IIIIIIIIIIII
+SELECT catalog_name, max_connections, available_connections, total_connections, /*cache_hits,*/ cache_misses, try_failures, thread_local_cache_enabled, max_lifetime_millis, idle_timeout_millis, reaper_thread_running, reaper_thread_period_millis, health_check_query
 FROM postgres_configure_pool()
 ORDER BY catalog_name
 ----
-s	8	1	0	FALSE	0	60000	1	30000	SELECT 1
-s1	8	1	0	FALSE	0	60000	1	30000	SELECT 1
+s	8	1	1	1	0	FALSE	0	60000	1	30000	SELECT 1
+s1	8	1	1	1	0	FALSE	0	60000	1	30000	SELECT 1
 
 query II
 SELECT catalog_name, acquire_mode

--- a/test/sql/storage/attach_rollback_throws.test
+++ b/test/sql/storage/attach_rollback_throws.test
@@ -1,0 +1,90 @@
+# name: test/sql/storage/attach_rollback_throws.test
+# description: Test that a throw on a server ROLLBACK or COMMIT does not leak a pool connection
+# group: [storage]
+
+# see: https://github.com/duckdb/duckdb-postgres/issues/545
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+# ROLLBACK throws
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+# a connection is opened on ATTACH and kept in the pool
+query II
+SELECT catalog_name, total_connections FROM postgres_configure_pool(catalog_name='s')
+----
+s	1
+
+# kill Postgres backend of our connection, ROLLBACK is attempted and fails
+statement error
+CALL postgres_execute('s', 'SELECT pg_terminate_backend(pg_backend_pid())')
+----
+pg_terminate_backend
+
+# connection must have been discarded, as it cannot pass the health check on returning it to the pool
+query II
+SELECT catalog_name, total_connections FROM postgres_configure_pool(catalog_name='s')
+----
+s	0
+
+statement ok
+DETACH s
+
+# COMMIT throws
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+SET VARIABLE s1_pid = (SELECT pid FROM postgres_query('s', 'SELECT pg_backend_pid() AS pid'))
+
+statement ok
+USE s
+
+statement ok
+BEGIN TRANSACTION
+
+query I
+FROM postgres_query('s', 'SELECT 42')
+----
+42
+
+statement ok
+SET pg_use_text_protocol=TRUE
+
+statement ok
+CALL postgres_query('s1', 'SELECT pg_terminate_backend($1)', params=row(getvariable(s1_pid)))
+
+statement ok
+RESET pg_use_text_protocol
+
+query II
+SELECT catalog_name, total_connections FROM postgres_configure_pool(catalog_name='s')
+----
+s	1
+
+statement error
+COMMIT
+----
+closed
+
+query II
+SELECT catalog_name, total_connections FROM postgres_configure_pool(catalog_name='s')
+----
+s	0
+
+statement ok
+DETACH s1
+
+statement ok
+USE memory
+
+statement ok
+DETACH s


### PR DESCRIPTION
It was discovered that when server `COMMIT` or `ROLLBACK` throws, the pool connection tied to the current transaction is not returned to pool.

This PR adds exception checks to those code paths.

Testing: new test is added that covers failures of both `COMMIT` and `ROLLBACK`.

Fixes: #545