### PR TITLE
Fix connection pool slot leak on COMMIT fail (1.5)

### DIFF
--- a/src/include/storage/postgres_transaction_manager.hpp
+++ b/src/include/storage/postgres_transaction_manager.hpp
@@ -26,6 +26,8 @@ public:
 	void Checkpoint(ClientContext &context, bool force = false) override;
 
 private:
+	void DestroyTransaction(Transaction &transaction);
+
 	PostgresCatalog &postgres_catalog;
 	mutex transaction_lock;
 	reference_map_t<Transaction, unique_ptr<PostgresTransaction>> transactions;

--- a/src/storage/postgres_transaction_manager.cpp
+++ b/src/storage/postgres_transaction_manager.cpp
@@ -16,19 +16,34 @@ Transaction &PostgresTransactionManager::StartTransaction(ClientContext &context
 	return result;
 }
 
-ErrorData PostgresTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction) {
-	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
-	postgres_transaction.Commit();
+void PostgresTransactionManager::DestroyTransaction(Transaction &transaction) {
 	lock_guard<mutex> l(transaction_lock);
 	transactions.erase(transaction);
-	return ErrorData();
+}
+
+ErrorData PostgresTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction) {
+	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
+	ErrorData error;
+	try {
+		postgres_transaction.Commit();
+	} catch (const std::exception &ex) {
+		error = ErrorData(ex);
+	} catch (...) {
+		error = ErrorData("Server COMMIT failed");
+	}
+	DestroyTransaction(transaction);
+	return error;
 }
 
 void PostgresTransactionManager::RollbackTransaction(Transaction &transaction) {
 	auto &postgres_transaction = transaction.Cast<PostgresTransaction>();
-	postgres_transaction.Rollback();
-	lock_guard<mutex> l(transaction_lock);
-	transactions.erase(transaction);
+	try {
+		postgres_transaction.Rollback();
+	} catch (...) {
+		DestroyTransaction(transaction);
+		throw;
+	}
+	DestroyTransaction(transaction);
 }
 
 void PostgresTransactionManager::Checkpoint(ClientContext &context, bool force) {


### PR DESCRIPTION
This is a backport of the PR #546 to `v1.5-variegata` stable branch.

It was discovered that when server `COMMIT` or `ROLLBACK` throws, the pool connection tied to the current transaction is not returned to pool.

This PR adds exception checks to those code paths.

Testing: new test is added that covers failures of both `COMMIT` and `ROLLBACK`.

Fixes: #545