### PR TITLE
Fix two libpq resource-handling bugs on COPY error paths

### DIFF
--- a/src/postgres_binary_reader.cpp
+++ b/src/postgres_binary_reader.cpp
@@ -59,12 +59,16 @@ bool PostgresBinaryReader::FetchNextBuffer() {
 		return false;
 	}
 
+	// take ownership of the buffer before validating it, so that a short read
+	// does not leak it - PQgetCopyData allocates even when it returns a length
+	// we cannot use
+	buffer = new_buffer;
+
 	// len -2 is error
 	// we expect at least 2 bytes in each message for the tuple count
 	if (!new_buffer || len < sizeof(int16_t)) {
 		throw IOException("Unable to read binary COPY data from Postgres: %s", string(PQerrorMessage(con.GetConn())));
 	}
-	buffer = new_buffer;
 	parser.SetBuffer(buffer, len);
 	return true;
 }

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -8,7 +8,8 @@ void PostgresConnection::BeginCopyFrom(ClientContext &context, const string &que
 	PostgresResult pg_res(PQExecute(context, query.c_str()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != expected_result) {
-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
 	}
 }
 

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -64,7 +64,8 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 	PostgresResult pg_res(PQExecute(context, query.c_str()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != PGRES_COPY_IN) {
-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
 	}
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a header
@@ -113,8 +114,8 @@ void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
 	PostgresResult pg_res(PQgetResult(GetConn()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
-		string error_msg(PQresultErrorMessage(result));
-		throw std::runtime_error("Failed to copy data: " + error_msg);
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to copy data: " + string(error));
 	}
 }
 


### PR DESCRIPTION
Two libpq resource-handling bugs on the COPY paths, found while looking into Snowflake-Labs/pg_lake#415.

`PostgresBinaryReader::FetchNextBuffer()` leaks the `PQgetCopyData` buffer when the message is shorter than the 2-byte tuple count it has to contain. `PQgetCopyData` allocates even when it returns a length we cannot use, and `buffer` was only assigned after the length check, so `FreeBuffer()` never saw it. Assigning it first hands it to the existing ownership, which frees it on the way out of the throw.

The three COPY error paths pass a possibly null `PGresult` to `PQresultErrorMessage()`. That does not crash - libpq returns an empty string - but it is how `Failed to copy data: ` with nothing after it gets produced, and a null result there means the connection failed, so the reason is on the connection. `ExecuteQueries()` and `PostgresQueryBind()` already do the `result ? PQresultErrorMessage(result) : PQerrorMessage(conn)` thing, so this just makes the COPY paths match.

The same report also covered a missing `PQfinish()` in `PGConnect()` and an undrained pipeline in `ExecuteQueries()`; both are already fixed on main, so they are not in this PR. For what it is worth, the `PQfinish()` one measured at about 19 kB per failed connection attempt in a long-lived process, so it was worth having.

No test - neither path is reachable from a well-behaved server.
