### PR TITLE
Fix two libpq leak bugs on COPY error paths (1.5)

### DIFF
--- a/src/postgres_binary_reader.cpp
+++ b/src/postgres_binary_reader.cpp
@@ -54,12 +54,16 @@ bool PostgresBinaryReader::FetchNextBuffer() {
 		return false;
 	}
 
+	// take ownership of the buffer before validating it, so that a short read
+	// does not leak it - PQgetCopyData allocates even when it returns a length
+	// we cannot use
+	buffer = new_buffer;
+
 	// len -2 is error
 	// we expect at least 2 bytes in each message for the tuple count
 	if (!new_buffer || len < sizeof(int16_t)) {
 		throw IOException("Unable to read binary COPY data from Postgres: %s", string(PQerrorMessage(con.GetConn())));
 	}
-	buffer = new_buffer;
 	parser.SetBuffer(buffer, len);
 	return true;
 }

--- a/src/postgres_copy_from.cpp
+++ b/src/postgres_copy_from.cpp
@@ -7,7 +7,8 @@ void PostgresConnection::BeginCopyFrom(ClientContext &context, const string &que
 	PostgresResult pg_res(PQExecute(context, query.c_str()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != expected_result) {
-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
 	}
 }
 

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -59,7 +59,8 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 	PostgresResult pg_res(PQExecute(context, query.c_str()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != PGRES_COPY_IN) {
-		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(PQresultErrorMessage(result)));
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to prepare COPY \"" + query + "\": " + string(error));
 	}
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a header
@@ -108,8 +109,8 @@ void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
 	PostgresResult pg_res(PQgetResult(GetConn()));
 	auto result = pg_res.res;
 	if (!result || PQresultStatus(result) != PGRES_COMMAND_OK) {
-		string error_msg(PQresultErrorMessage(result));
-		throw std::runtime_error("Failed to copy data: " + error_msg);
+		auto error = result ? PQresultErrorMessage(result) : PQerrorMessage(GetConn());
+		throw std::runtime_error("Failed to copy data: " + string(error));
 	}
 }
 


### PR DESCRIPTION
This is a backport of the PR #555 to `v1.5-variegata` stable branch.

PostgresBinaryReader::FetchNextBuffer() leaked the PQgetCopyData buffer when the message was shorter than the tuple count it has to contain. PQgetCopyData allocates even when it hands back a length we cannot use, and buffer was only assigned after the check, so FreeBuffer() never saw it. Assign it first and let the existing ownership do the freeing.

The three COPY error paths passed a possibly null PGresult to PQresultErrorMessage(). libpq returns an empty string rather than crashing, which is how "Failed to copy data: " with no reason after it gets produced. A null result means the connection failed, so report PQerrorMessage() in that case - the same pattern ExecuteQueries() and PostgresQueryBind() already use.

Reported as https://github.com/Snowflake-Labs/pg_lake/issues/415.