### PR TITLE
Added unbound/out of bounds numeric -> varchar option

### DIFF
--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -25,6 +25,13 @@ struct PostgresTypeData {
 	idx_t array_dimensions = 0;
 };
 
+struct PostgresTypeConfig {
+	bool array_as_varchar = false;
+	bool numeric_as_varchar = false;
+
+	static PostgresTypeConfig FromContext(optional_ptr<ClientContext> context);
+};
+
 enum class PostgresTypeAnnotation {
 	STANDARD,
 	CAST_TO_VARCHAR,
@@ -69,7 +76,8 @@ public:
 	static string DataTypeToTypeName(const string &data_type);
 	static LogicalType ToPostgresType(const LogicalType &input);
 	static LogicalType TypeToLogicalType(optional_ptr<PostgresTransaction> transaction,
-	                                     optional_ptr<PostgresSchemaEntry> schema, const PostgresTypeData &input,
+	                                     optional_ptr<PostgresSchemaEntry> schema,
+	                                     const PostgresTypeConfig &type_config, const PostgresTypeData &input,
 	                                     PostgresType &postgres_type);
 	static string TypeToString(const LogicalType &input);
 	static string PostgresOidToName(uint32_t oid);

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -52,11 +52,12 @@ protected:
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, RemoveColumnInfo &info);
 
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
-	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info);
+	                      const PostgresTypeConfig &type_config, PostgresResult &result, idx_t row,
+	                      PostgresTableInfo &table_info);
 	static void AddConstraint(PostgresResult &result, idx_t row, PostgresTableInfo &table_info);
 	static void AddColumnOrConstraint(optional_ptr<PostgresTransaction> transaction,
-	                                  optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result, idx_t row,
-	                                  PostgresTableInfo &table_info);
+	                                  optional_ptr<PostgresSchemaEntry> schema, const PostgresTypeConfig &type_config,
+	                                  PostgresResult &result, idx_t row, PostgresTableInfo &table_info);
 
 	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end);
 

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -188,6 +188,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "pg_array_as_varchar", "Read Postgres arrays as varchar - enables reading mixed dimensional arrays",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
 	config.AddExtensionOption(
+	    "pg_numeric_as_varchar",
+	    "Read Postgres numerics without precision and scale or precision > 38 as varchar instead of double",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption(
 	    "pg_connection_cache",
 	    "Whether or not to use the connection pooling."
 	    " This option is deprecated, instead to disable the connection pooling use \"SET pg_pool_max_connections=0\" "

--- a/src/postgres_query.cpp
+++ b/src/postgres_query.cpp
@@ -102,13 +102,14 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
 		PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result, 0);
 		return std::move(result);
 	}
+	auto type_config = PostgresTypeConfig::FromContext(context);
 	for (idx_t c = 0; c < nfields; c++) {
 		PostgresType postgres_type;
 		postgres_type.oid = PQftype(describe_prepared, c);
 		PostgresTypeData type_data;
 		type_data.type_name = PostgresUtils::PostgresOidToName(postgres_type.oid);
 		type_data.type_modifier = PQfmod(describe_prepared, c);
-		auto converted_type = PostgresUtils::TypeToLogicalType(nullptr, nullptr, type_data, postgres_type);
+		auto converted_type = PostgresUtils::TypeToLogicalType(nullptr, nullptr, type_config, type_data, postgres_type);
 		result->postgres_types.push_back(postgres_type);
 		return_types.emplace_back(converted_type);
 		names.emplace_back(PQfname(describe_prepared, c));

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -181,25 +181,32 @@ uint32_t PostgresUtils::TypeNameToPostgresOid(const string &type_name) {
 	return 0;
 }
 
+PostgresTypeConfig PostgresTypeConfig::FromContext(optional_ptr<ClientContext> context) {
+	PostgresTypeConfig result;
+	if (!context) {
+		return result;
+	}
+	Value setting;
+	if (context->TryGetCurrentSetting("pg_array_as_varchar", setting)) {
+		result.array_as_varchar = BooleanValue::Get(setting);
+	}
+	if (context->TryGetCurrentSetting("pg_numeric_as_varchar", setting)) {
+		result.numeric_as_varchar = BooleanValue::Get(setting);
+	}
+	return result;
+}
+
 LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> transaction,
                                              optional_ptr<PostgresSchemaEntry> schema,
-                                             const PostgresTypeData &type_info, PostgresType &postgres_type) {
+                                             const PostgresTypeConfig &type_config, const PostgresTypeData &type_info,
+                                             PostgresType &postgres_type) {
 	auto &pgtypename = type_info.type_name;
 
 	// postgres array types start with an _
 	if (StringUtil::StartsWith(pgtypename, "_")) {
-		if (transaction) {
-			auto context = transaction->GetContext();
-			if (!context) {
-				throw InternalException("Context is destroyed!?");
-			}
-			Value array_as_varchar;
-			if (context->TryGetCurrentSetting("pg_array_as_varchar", array_as_varchar)) {
-				if (BooleanValue::Get(array_as_varchar)) {
-					postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
-					return LogicalType::VARCHAR;
-				}
-			}
+		if (type_config.array_as_varchar) {
+			postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
+			return LogicalType::VARCHAR;
 		}
 		// get the array dimension information
 		idx_t dimensions = type_info.array_dimensions;
@@ -212,7 +219,8 @@ LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> t
 		child_type_info.type_modifier = type_info.type_modifier;
 		child_type_info.type_schema = type_info.type_schema;
 		PostgresType child_pg_type;
-		auto child_type = PostgresUtils::TypeToLogicalType(transaction, schema, child_type_info, child_pg_type);
+		auto child_type =
+		    PostgresUtils::TypeToLogicalType(transaction, schema, type_config, child_type_info, child_pg_type);
 		// populate the child OID from the actual Postgres type name
 		if (child_pg_type.oid == 0) {
 			child_pg_type.oid = TypeNameToPostgresOid(child_type_info.type_name);
@@ -247,7 +255,10 @@ LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> t
 		auto width = ((type_info.type_modifier - sizeof(int32_t)) >> 16) & 0xffff;
 		auto scale = (((type_info.type_modifier - sizeof(int32_t)) & 0x7ff) ^ 1024) - 1024;
 		if (type_info.type_modifier == -1 || width < 0 || scale < 0 || width > 38) {
-			// fallback to double
+			if (type_config.numeric_as_varchar) {
+				postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
+				return LogicalType::VARCHAR;
+			}
 			postgres_type.info = PostgresTypeAnnotation::NUMERIC_AS_DOUBLE;
 			return LogicalType::DOUBLE;
 		}

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -96,8 +96,8 @@ ORDER BY table_schema, table_name, ordinal_position;
 }
 
 void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
-                                 optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result, idx_t row,
-                                 PostgresTableInfo &table_info) {
+                                 optional_ptr<PostgresSchemaEntry> schema, const PostgresTypeConfig &type_config,
+                                 PostgresResult &result, idx_t row, PostgresTableInfo &table_info) {
 	PostgresTypeData type_info;
 	idx_t column_index = 3;
 	auto column_name = result.GetString(row, column_index);
@@ -113,7 +113,7 @@ void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
 	string default_value;
 
 	PostgresType postgres_type;
-	auto column_type = PostgresUtils::TypeToLogicalType(transaction, schema, type_info, postgres_type);
+	auto column_type = PostgresUtils::TypeToLogicalType(transaction, schema, type_config, type_info, postgres_type);
 	table_info.postgres_types.push_back(std::move(postgres_type));
 	table_info.postgres_names.push_back(column_name);
 	ColumnDefinition column(Identifier(std::move(column_name)), std::move(column_type));
@@ -165,13 +165,14 @@ void PostgresTableSet::AddConstraint(PostgresResult &result, idx_t row, Postgres
 }
 
 void PostgresTableSet::AddColumnOrConstraint(optional_ptr<PostgresTransaction> transaction,
-                                             optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result,
-                                             idx_t row, PostgresTableInfo &table_info) {
+                                             optional_ptr<PostgresSchemaEntry> schema,
+                                             const PostgresTypeConfig &type_config, PostgresResult &result, idx_t row,
+                                             PostgresTableInfo &table_info) {
 	if (result.IsNull(row, 3)) {
 		// constraint
 		AddConstraint(result, row, table_info);
 	} else {
-		AddColumn(transaction, schema, result, row, table_info);
+		AddColumn(transaction, schema, type_config, result, row, table_info);
 	}
 }
 
@@ -179,6 +180,7 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 	vector<unique_ptr<PostgresTableInfo>> tables;
 	unique_ptr<PostgresTableInfo> info;
 
+	auto type_config = PostgresTypeConfig::FromContext(transaction.GetContext());
 	for (idx_t row = start; row < end; row++) {
 		auto table_name = result.GetString(row, 1);
 		if (!info || info->GetTableName() != table_name) {
@@ -192,7 +194,7 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 				info->create_info->comment = Value(result.GetString(row, 14));
 			}
 		}
-		AddColumnOrConstraint(&transaction, &schema, result, row, *info);
+		AddColumnOrConstraint(&transaction, &schema, type_config, result, row, *info);
 	}
 	if (info) {
 		tables.push_back(std::move(info));
@@ -252,8 +254,9 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 		return nullptr;
 	}
 	auto table_info = make_uniq<PostgresTableInfo>(schema, table_name);
+	auto type_config = PostgresTypeConfig::FromContext(transaction.GetContext());
 	for (idx_t row = 0; row < rows; row++) {
-		AddColumnOrConstraint(&transaction, &schema, *result, row, *table_info);
+		AddColumnOrConstraint(&transaction, &schema, type_config, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->IsNull(0, 2) ? 0 : result->GetInt64(0, 2);
 	// Read table-level comment from 14
@@ -274,8 +277,9 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(ClientContext &cont
 		throw InvalidInputException("Table %s does not contain any columns.", table_name);
 	}
 	auto table_info = make_uniq<PostgresTableInfo>(schema_name, table_name);
+	auto type_config = PostgresTypeConfig::FromContext(context);
 	for (idx_t row = 0; row < rows; row++) {
-		AddColumnOrConstraint(nullptr, nullptr, *result, row, *table_info);
+		AddColumnOrConstraint(nullptr, nullptr, type_config, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->IsNull(0, 2) ? 0 : result->GetInt64(0, 2);
 	// Read table-level comment

--- a/src/storage/postgres_type_set.cpp
+++ b/src/storage/postgres_type_set.cpp
@@ -118,14 +118,16 @@ void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, Post
 	info.SetTypeName(Identifier(result.GetString(start_row, 2)));
 
 	child_list_t<LogicalType> child_types;
+	auto type_config = PostgresTypeConfig::FromContext(transaction.GetContext());
 	for (idx_t row = start_row; row < end_row; row++) {
 		auto type_name = result.GetString(row, 3);
 		PostgresTypeData type_data;
 		type_data.type_name = result.GetString(row, 4);
 		type_data.type_schema = result.GetString(row, 5);
 		PostgresType child_type;
-		child_types.push_back(make_pair(
-		    Identifier(type_name), PostgresUtils::TypeToLogicalType(&transaction, &schema, type_data, child_type)));
+		child_types.push_back(
+		    make_pair(Identifier(type_name),
+		              PostgresUtils::TypeToLogicalType(&transaction, &schema, type_config, type_data, child_type)));
 		postgres_type.children.push_back(std::move(child_type));
 	}
 	info.type = LogicalType::STRUCT(std::move(child_types));

--- a/test/sql/storage/attach_existing_multidimensional_array.test
+++ b/test/sql/storage/attach_existing_multidimensional_array.test
@@ -54,3 +54,10 @@ SELECT * FROM mixed_arrays
 ----
 {{{1,2,3}},{{4,5,6}},{{7,8,9}}}
 {1,2,3}
+
+# pg_array_as_varchar also applies to postgres_query
+query I
+SELECT * FROM postgres_query('s', 'SELECT * FROM mixed_arrays')
+----
+{{{1,2,3}},{{4,5,6}},{{7,8,9}}}
+{1,2,3}

--- a/test/sql/storage/attach_numeric_as_varchar.test
+++ b/test/sql/storage/attach_numeric_as_varchar.test
@@ -1,0 +1,116 @@
+# name: test/sql/storage/attach_numeric_as_varchar.test
+# description: Test reading unbound numerics as varchar with pg_numeric_as_varchar
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS unbound_numerics')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE unbound_numerics(n NUMERIC)')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO unbound_numerics VALUES (12345678901234567890123456789012345678901234567890), (0.12345678901234567890123456789012345678901234567890), (NULL)')
+
+# by default unbound numerics are read as double
+query I
+SELECT typeof(n) FROM s.unbound_numerics LIMIT 1
+----
+DOUBLE
+
+statement ok
+SET pg_numeric_as_varchar=true
+
+statement ok
+CALL pg_clear_cache();
+
+# with pg_numeric_as_varchar the values are read as varchar without precision loss
+query I
+SELECT typeof(n) FROM s.unbound_numerics LIMIT 1
+----
+VARCHAR
+
+query I
+SELECT n FROM s.unbound_numerics
+----
+12345678901234567890123456789012345678901234567890
+0.12345678901234567890123456789012345678901234567890
+NULL
+
+# the setting also applies to postgres_query
+query I
+SELECT * FROM postgres_query('s', 'SELECT n FROM unbound_numerics WHERE n > 1')
+----
+12345678901234567890123456789012345678901234567890
+
+# unbound numerics inside arrays
+statement ok
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS unbound_numeric_arrays')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE unbound_numeric_arrays(n NUMERIC[])')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO unbound_numeric_arrays VALUES (ARRAY[12345678901234567890123456789012345678901234567890::NUMERIC, 2])')
+
+statement ok
+CALL pg_clear_cache();
+
+query I
+SELECT n FROM s.unbound_numeric_arrays
+----
+[12345678901234567890123456789012345678901234567890, 2]
+
+# bounded numerics with a precision above DuckDB's decimal maximum of 38 take the same fallback
+statement ok
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS oversized_numerics')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE oversized_numerics(n NUMERIC(50,10))')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO oversized_numerics VALUES (1234567890123456789012345678901234567890.0123456789)')
+
+statement ok
+CALL pg_clear_cache();
+
+query I
+SELECT typeof(n) FROM s.oversized_numerics
+----
+VARCHAR
+
+query I
+SELECT n FROM s.oversized_numerics
+----
+1234567890123456789012345678901234567890.0123456789
+
+statement ok
+SET pg_numeric_as_varchar=false
+
+statement ok
+CALL pg_clear_cache();
+
+query I
+SELECT typeof(n) FROM s.unbound_numerics LIMIT 1
+----
+DOUBLE
+
+query I
+SELECT typeof(n) FROM s.oversized_numerics
+----
+DOUBLE
+
+statement ok
+CALL postgres_execute('s', 'DROP TABLE unbound_numerics')
+
+statement ok
+CALL postgres_execute('s', 'DROP TABLE oversized_numerics')
+
+statement ok
+CALL postgres_execute('s', 'DROP TABLE unbound_numeric_arrays')


### PR DESCRIPTION
Follow through of [issue 557](https://github.com/duckdb/duckdb-postgres/issues/557)

- added numeric -> varchar option instead of falling back to double
- added type config and included existing pg_array_as_varchar setting 
- fixed issue of settings being ignored for postgres_query, postgres_scan, and postgres_table_set